### PR TITLE
Fix for Issue "Incorrect link to MAINTAINER.md"

### DIFF
--- a/HOW_TO_LEAD_A_PROJECT.md
+++ b/HOW_TO_LEAD_A_PROJECT.md
@@ -22,7 +22,7 @@ You will:
 
 1. Start contributing to the project
 2. Talk to an officer or open an issue like: “I’d like to help maintain this project!”
-3. We’ll give you write access and add your name to [MAINTAINERS.md]('/MAINTAINERS.md')
+3. We’ll give you write access and add your name to [MAINTAINERS.md](./MAINTAINERS.md)
 4. You’re now a lead!
 
 ---

--- a/HOW_TO_LEAD_A_PROJECT.md
+++ b/HOW_TO_LEAD_A_PROJECT.md
@@ -22,7 +22,7 @@ You will:
 
 1. Start contributing to the project
 2. Talk to an officer or open an issue like: “I’d like to help maintain this project!”
-3. We’ll give you write access and add your name to [MAINTAINERS.md]('./MAINTAINERS.md')
+3. We’ll give you write access and add your name to [MAINTAINERS.md]('/MAINTAINERS.md')
 4. You’re now a lead!
 
 ---

--- a/HOW_TO_LEAD_A_PROJECT.md
+++ b/HOW_TO_LEAD_A_PROJECT.md
@@ -22,7 +22,7 @@ You will:
 
 1. Start contributing to the project
 2. Talk to an officer or open an issue like: “I’d like to help maintain this project!”
-3. We’ll give you write access and add your name to [MAINTAINERS.md]('./MAINTAINERS.md]')
+3. We’ll give you write access and add your name to [MAINTAINERS.md]('./MAINTAINERS.md')
 4. You’re now a lead!
 
 ---

--- a/HOW_TO_LEAD_A_PROJECT.md
+++ b/HOW_TO_LEAD_A_PROJECT.md
@@ -22,7 +22,7 @@ You will:
 
 1. Start contributing to the project
 2. Talk to an officer or open an issue like: “I’d like to help maintain this project!”
-3. We’ll give you write access and add your name to [MAINTAINERS.md]('#')
+3. We’ll give you write access and add your name to [MAINTAINERS.md]('./MAINTAINERS.md]')
 4. You’re now a lead!
 
 ---


### PR DESCRIPTION
### WHAT:
Replaced the '#' inside the link to the MAINTAINERS.md file with the actual link "./MAINTAINERS.md".

### WHY:
Without the actual link replacing the "#" in '[MAINTAINERS.md]('#')', the user will be met with an error 404.